### PR TITLE
DBP-336-node-heap-limit

### DIFF
--- a/.github/workflows/check-nest-test-sonarcloud.yaml
+++ b/.github/workflows/check-nest-test-sonarcloud.yaml
@@ -11,8 +11,14 @@ on:
         type: string
         description: "Deployment stage"
         required: true
+      node_heap_size:
+        type: number
+        description: "Heap Size for node in MB"
+        required: false
+        default: 4096
 env:
   NODE_VERSION: ${{ inputs.node_version }} # needed for npm test
+  NODE_OPTIONS: "--max-old-space-size=${{ inputs.node_heap_size }}"
   DEPLOY_STAGE: ${{ inputs.deploy_stage }}
 
 jobs:


### PR DESCRIPTION
# Description
Add option to set the heap limit for node in the nest test workflow, because the default limit (2048) was reached and it failed. Default is now 4096MB.
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
[DBP-336](https://ticketsystem.dbildungscloud.de/browse/DBP-336)
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.