### PR TITLE
dbp-608-Fixed commit SHA for external Jobs

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  #v3.5
         with:
-          version: 3.5.0 
+          version: 3.12.*
 
       - name: Helm Repository Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -60,7 +60,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com" 
 
       - name: Install Helm
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f #v4.0.0
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 #v3.5
         with:
           version: 3.5.0 
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -60,7 +60,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com" 
 
       - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 #v3.5
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  #v3.5
         with:
           version: 3.5.0 
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  #v3.5
         with:
-          version: 3.12.*
+          version: 3.12.3
 
       - name: Helm Repository Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -60,7 +60,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com" 
 
       - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 #v3.5
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f #v4.0.0
         with:
           version: 3.5.0 
 

--- a/.github/workflows/check-codeql.yaml
+++ b/.github/workflows/check-codeql.yaml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  #v4.1.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@bad341350a2f5616f9e048e51360cedc49181ce8 #v2.15.1
+        uses: github/codeql-action/init@cf7e9f23492505046de9a37830c3711dd0f25bb3 #v2.16.2
         with:
           languages: javascript
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@bad341350a2f5616f9e048e51360cedc49181ce8 #v2.15.1
+        uses: github/codeql-action/analyze@65c74964a9ed8c44ed9f19d4bbc5757a6a8e9ab9 #v2.16.1
         with:
           category: /language:javascript

--- a/.github/workflows/check-helm-kics.yaml
+++ b/.github/workflows/check-helm-kics.yaml
@@ -18,7 +18,7 @@ jobs:
 
       steps:
         - name: Checkout repository
-          uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  #v4.1.1
 
         - name: Scan with kics
           uses: checkmarx/kics-github-action@8a44970e3d2eca668be41abe9d4e06709c3b3609 #v1.7.0

--- a/.github/workflows/check-nest-lint.yaml
+++ b/.github/workflows/check-nest-lint.yaml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  #v4.1.1
 
       - name: Setup node
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d #v3.8.1
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/check-nest-test-sonarcloud.yaml
+++ b/.github/workflows/check-nest-test-sonarcloud.yaml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  #v4.1.1
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         run: docker --version
 
       - name: Inject Secrets
-        uses: timheuer/base64-to-file@ca9e30baf83f7f26708fb0059af9a0973fe5f27e #v1.2.3
+        uses: timheuer/base64-to-file@784a1a4a994315802b7d8e2084e116e783d157be #v1.2.4
         with:
           fileName: 'secrets.json'
           fileDir: './config/'
@@ -57,7 +57,7 @@ jobs:
           encodedString: ewogICAgIkRCIjogewogICAgICAgICJTRUNSRVQiOiAiVmVyeSBoaWRkZW4gc2VjcmV0IgogICAgfSwKICAgICJLRVlDTE9BSyI6IHsKICAgICAgICAiQURNSU5fU0VDUkVUIjogIkNsaWVudCBTZWNyZXQiCiAgICB9Cn0=
 
       - name: Setup node
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d #v3.8.1
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -76,13 +76,13 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ !inputs.skip_tests }}
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  #v4.3.1
         with:
           name: test-artifacts
           path: artifacts/
 
       - name: SonarCloud upload
-        uses: SonarSource/sonarcloud-github-action@c25d2e7e3def96d0d1781000d3c429da22cd6252 #v2.0.2
+        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 #v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -65,6 +65,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@65c74964a9ed8c44ed9f19d4bbc5757a6a8e9ab9 #v2.16.1
+        uses: github/codeql-action/upload-sarif@ece8414c725e29de2e18c0859fda9e7280df9488 #v3.24.2
         with:
             sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -42,7 +42,7 @@ jobs:
             image_ref: '${{ inputs.image_ref }}'
         run: echo "output=${image_ref,,}" >> $GITHUB_OUTPUT
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe #v0.12.0
+        uses: aquasecurity/trivy-action@84384bd6e777ef152729993b8145ea352e9dd3ef #v0.17.0
         with:
           image-ref: ${{ steps.image_ref_lower.outputs.output }}
           format: "sarif"
@@ -65,6 +65,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@0116bc2df50751f9724a2e35ef1f24d22f90e4e1 #v2.22.3
+        uses: github/codeql-action/upload-sarif@65c74964a9ed8c44ed9f19d4bbc5757a6a8e9ab9 #v2.16.1
         with:
             sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Build image name and tags
         id: docker_meta_img
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 #v5.0.0
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: ${{ inputs.container_registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
           tags: |
@@ -94,7 +94,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
         id: docker_build_push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
         with:
           context: ${{ inputs.context }}
           platforms: linux/amd64


### PR DESCRIPTION
For external jobs, it is recommended to use fixed commit SHA references.

TODO:

Identify all external jobs currently referenced in our CI/CD workflows.
Update the workflow configurations to reference the external jobs using their respective commit SHAs instead of semantic versions.
AC:

All references to external jobs in the CI/CD workflows must use a fixed commit SHA.

# Description

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.