### PR TITLE
OPS-5649-update-nextcloud-add-target-option-for-docker-build

### DIFF
--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -60,7 +60,7 @@ on:
         default: ""
         type: string
       target:
-        description: "If defined you set the target build stage to build."
+        description: "If defined you specify a build stage to stop at when building a multi-stage Dockerfile"
         required: false
         default: ""
         type: string

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -60,7 +60,7 @@ on:
         default: ""
         type: string
       target:
-        description: "If defined you can set which target should be used in the Dockerfile"
+        description: "If defined you set the target build stage to build."
         required: false
         default: ""
         type: string

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -59,7 +59,11 @@ on:
         required: false
         default: ""
         type: string
-
+      target:
+        description: "If defined you can set which target should be used in the Dockerfile"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   build_and_upload_image:
@@ -101,6 +105,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta_img.outputs.tags }}
           labels: ${{ steps.docker_meta_img.outputs.labels }}
+          target: ${{ inputs.target }}
   trivy_scan:
     name: Trivy scan for uploaded image
     # Wait for image upload


### PR DESCRIPTION
# Description

- add the option to give the target option to the docker build command

Change can be seen in action, since it returns the command it uses: 
- tested it with setting it: https://github.com/hpi-schul-cloud/schulcloud-nextcloud/actions/runs/7916024473/job/21609050527
- tested it without setting it: https://github.com/hpi-schul-cloud/schulcloud-nextcloud/actions/runs/7915964050/job/21608872201

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.