### PR TITLE
Ops-6222 enable multi registry pushes

### DIFF
--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -149,16 +149,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-      #   id: docker_build_push
-      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-      #   with:
-      #     context: ${{ inputs.context }}
-      #     platforms: linux/amd64
-      #     push: true
-      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
-      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
-      #     target: ${{ inputs.target }}
+      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+        id: docker_build_push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+        with:
+          context: ${{ inputs.context }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_img.outputs.tags }}
+          labels: ${{ steps.docker_meta_img.outputs.labels }}
+          target: ${{ inputs.target }}
   
   pre_scan:
     runs-on: ubuntu-latest
@@ -171,25 +171,25 @@ jobs:
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/'${{ inputs.dockerhub_repository_owner }}"
+            echo "registry_and_owner=docker.io/${{ inputs.dockerhub_repository_owner }}"
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
             echo "registry_and_owner=quay.io/${{ inputs.quay_repository_owner }}"
           elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
             echo "registry_and_owner=ghcr.io/${{ github.repository_owner }}"
           fi
 
-  # trivy_scan:
-  #   name: Trivy scan for uploaded image
-  #   # Wait for image upload
-  #   needs: [build_and_upload_image, pre_scan]
-  #   if: ${{ inputs.run_trivy_scan }}
-  #   permissions:
-  #     packages: read
-  #     security-events: write
-  #   uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
-  #   with:
-  #     image_ref: '${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
-  #     severity: ${{ inputs.trivy_severity }}
-  #     fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
-  #     ignore-unfixed: ${{ inputs.ignore-unfixed }}
-  #     report_location: ${{ inputs.report_location }}
+  trivy_scan:
+    name: Trivy scan for uploaded image
+    # Wait for image upload
+    needs: [build_and_upload_image, pre_scan]
+    if: ${{ inputs.run_trivy_scan }}
+    permissions:
+      packages: read
+      security-events: write
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
+    with:
+      image_ref: '${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
+      severity: ${{ inputs.trivy_severity }}
+      fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
+      ignore-unfixed: ${{ inputs.ignore-unfixed }}
+      report_location: ${{ inputs.report_location }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -36,10 +36,6 @@ on:
         description: "Generation of the image tag: ticket_from_branch, commit_hash or version_git_tag"
         required: false
         type: string
-      custom_image_tag:
-        description: "Custom image tag. Required when tag generation is disabled."
-        required: false
-        type: string
       context:
         description: "Directory where the image is built, defaults to repository root"
         required: false
@@ -103,9 +99,6 @@ jobs:
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} && -z "${{ inputs.quay_repository_owner }}" ]]; then
             echo "Error: when pushing to quay.io a repository owner is required."
             exit 1
-          elif [[ -z "${{ inputs.image_tag_generation }}" && -z "${{ inputs.custom_image_tag }}" ]]; then
-            echo "Error: when image tag generation is disabled a custom image tag is required."
-            exit 1
           fi
 
       - name: Checkout Code
@@ -122,7 +115,7 @@ jobs:
           tags: |
             type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
-            type=match,pattern=\d.\d.\d,enable=${{ inputs.image_tag_generation == 'version_custom_git_tag' }}
+            type=match,pattern=\d.\d.\d,enable=${{ inputs.image_tag_generation == 'simple_version_git_tag' }}
             type=sha,enable=${{ inputs.image_tag_generation == 'commit_hash' }}
             type=pep440,pattern={{version}},enable=${{ inputs.image_tag_generation == 'version_git_tag' }}
           flavor: |

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -33,7 +33,7 @@ on:
         type: boolean
         default: false
       image_tag_generation:
-        description: "Generation of the image tag: ticket_from_branch, commit_hash or version_git_tag"
+        description: "Comma separated list of image tag generation strategies: ticket_from_branch, commit_hash, version_git_tag, mmp_semver_git_tag oder mm_semver_git_tag"
         required: false
         type: string
       context:
@@ -113,11 +113,11 @@ jobs:
             name=docker.io/${{ inputs.dockerhub_repository_owner }}/${{ inputs.image_name }},enable=${{ contains(inputs.container_registry, 'dockerhub') }}
             name=quay.io/${{ inputs.quay_repository_owner }}/${{ inputs.image_name }},enable=${{ contains(inputs.container_registry, 'quay.io') }}
           tags: |
-            type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
-            type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
-            type=match,pattern=\d.\d.\d,enable=${{ inputs.image_tag_generation == 'simple_version_git_tag' }}
+            type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ contains(inputs.image_tag_generation, 'ticket_from_branch') }}
+            type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ contains(inputs.image_tag_generation, 'ticket_from_branch') }}
+            type=semver,value={{tag}},pattern={{version}},enable=${{ contains(inputs.image_tag_generation, 'mmp_semver_git_tag') }}
             type=sha,enable=${{ inputs.image_tag_generation == 'commit_hash' }}
-            type=pep440,pattern={{version}},enable=${{ inputs.image_tag_generation == 'version_git_tag' }}
+            type=pep440,pattern={{version}},enable=${{ contains(inputs.image_tag_generation, 'version_git_tag') }}
           flavor: |
             latest=${{ inputs.add_latest_tag }}
       

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -149,16 +149,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-        id: docker_build_push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-        with:
-          context: ${{ inputs.context }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta_img.outputs.tags }}
-          labels: ${{ steps.docker_meta_img.outputs.labels }}
-          target: ${{ inputs.target }}
+      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+      #   id: docker_build_push
+      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+      #   with:
+      #     context: ${{ inputs.context }}
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
+      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
+      #     target: ${{ inputs.target }}
   
   pre_scan:
     runs-on: ubuntu-latest
@@ -171,11 +171,11 @@ jobs:
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/${{ inputs.dockerhub_repository_owner }}"
+            echo "registry_and_owner=docker.io/${{ inputs.dockerhub_repository_owner }}" >> $GITHUB_OUTPUT
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
-            echo "registry_and_owner=quay.io/${{ inputs.quay_repository_owner }}"
+            echo "registry_and_owner=quay.io/${{ inputs.quay_repository_owner }}" >> $GITHUB_OUTPUT
           elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
-            echo "registry_and_owner=ghcr.io/${{ github.repository_owner }}"
+            echo "registry_and_owner=ghcr.io/${{ github.repository_owner }}" >> $GITHUB_OUTPUT
           fi
 
   trivy_scan:

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -116,9 +116,9 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: | 
-            name="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'ghcr.io') }}
-            name="docker.io/${{ inputs.dockerhub_repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'dockerhub') }}
-            name="quay.io/${{ inputs.quay_repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'quay.io') }}
+            name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }},enable=${{ contains(inputs.container_registry, 'ghcr.io') }}
+            name=docker.io/${{ inputs.dockerhub_repository_owner }}/${{ inputs.image_name }},enable=${{ contains(inputs.container_registry, 'dockerhub') }}
+            name=quay.io/${{ inputs.quay_repository_owner }}/${{ inputs.image_name }},enable=${{ contains(inputs.container_registry, 'quay.io') }}
           tags: |
             type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -147,16 +147,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-      #   id: docker_build_push
-      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-      #   with:
-      #     context: ${{ inputs.context }}
-      #     platforms: linux/amd64
-      #     push: true
-      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
-      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
-      #     target: ${{ inputs.target }}
+      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+        id: docker_build_push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+        with:
+          context: ${{ inputs.context }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_img.outputs.tags }}
+          labels: ${{ steps.docker_meta_img.outputs.labels }}
+          target: ${{ inputs.target }}
   
   trivy_scan:
     name: Trivy scan for uploaded image

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -171,25 +171,25 @@ jobs:
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/$inputs.dockerhub_repository_owner"
+            echo "registry_and_owner=docker.io/'$inputs.dockerhub_repository_owner'"
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
-            echo "registry_and_owner=quay.io/$inputs.quay_repository_owner"
+            echo "registry_and_owner=quay.io/'$inputs.quay_repository_owner'"
           elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
-            echo "registry_and_owner=ghcr.io/$github.repository_owner"
+            echo "registry_and_owner=ghcr.io/'$github.repository_owner'"
           fi
 
-  trivy_scan:
-    name: Trivy scan for uploaded image
-    # Wait for image upload
-    needs: [build_and_upload_image, pre_scan]
-    if: ${{ inputs.run_trivy_scan }}
-    permissions:
-      packages: read
-      security-events: write
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
-    with:
-      image_ref: '${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
-      severity: ${{ inputs.trivy_severity }}
-      fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
-      ignore-unfixed: ${{ inputs.ignore-unfixed }}
-      report_location: ${{ inputs.report_location }}
+  # trivy_scan:
+  #   name: Trivy scan for uploaded image
+  #   # Wait for image upload
+  #   needs: [build_and_upload_image, pre_scan]
+  #   if: ${{ inputs.run_trivy_scan }}
+  #   permissions:
+  #     packages: read
+  #     security-events: write
+  #   uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
+  #   with:
+  #     image_ref: '${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
+  #     severity: ${{ inputs.trivy_severity }}
+  #     fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
+  #     ignore-unfixed: ${{ inputs.ignore-unfixed }}
+  #     report_location: ${{ inputs.report_location }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -122,6 +122,7 @@ jobs:
           tags: |
             type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
+            type=match,pattern=\d.\d.\d,enable=${{ inputs.image_tag_generation == 'version_custom_git_tag' }}
             type=sha,enable=${{ inputs.image_tag_generation == 'commit_hash' }}
             type=pep440,pattern={{version}},enable=${{ inputs.image_tag_generation == 'version_git_tag' }}
           flavor: |

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -1,5 +1,7 @@
-# Builds and uploads a docker image and scans it with trivy (optional)
+# Builds and uploads a docker image to multiple repositories and scans it with trivy (optional)
 # Trivy scan can be disabled
+# dockerhub_repository_owner: required when pushing to dockerhub
+# quay_repository_owner: required when pushing to quay.io 
 # Image tag options: 
 # image_tag_generation: "ticket_from_branch" The ticket is extracted from the branch name (e.g. OPS-123-testing -> OPS-123)
 # image_tag_generation: "commit_hash" Short hash of the commit is used as tag
@@ -147,29 +149,43 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-      #   id: docker_build_push
-      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-      #   with:
-      #     context: ${{ inputs.context }}
-      #     platforms: linux/amd64
-      #     push: true
-      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
-      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
-      #     target: ${{ inputs.target }}
+      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+        id: docker_build_push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+        with:
+          context: ${{ inputs.context }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_img.outputs.tags }}
+          labels: ${{ steps.docker_meta_img.outputs.labels }}
+          target: ${{ inputs.target }}
   
   trivy_scan:
     name: Trivy scan for uploaded image
+    runs-on: ubuntu-latest
     # Wait for image upload
     needs: build_and_upload_image
     if: ${{ inputs.run_trivy_scan }}
     permissions:
       packages: read
       security-events: write
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
-    with:
-      image_ref: '${{ inputs.container_registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
-      severity: ${{ inputs.trivy_severity }}
-      fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
-      ignore-unfixed: ${{ inputs.ignore-unfixed }}
-      report_location: ${{ inputs.report_location }}
+    steps:
+      - name: Build image ref
+        id: registry_and_owner
+        run: |
+          if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
+            echo "registry_and_owner=docker.io/$dockerhub_repository_owner/"
+          elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
+          echo "registry_and_owner=quay.io/$quay_repository_owner/"
+          elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
+          echo "registry_and_owner=ghcr.io/$github.repository_owner/"
+          fi
+
+      - name: Trivy scan
+        uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
+        with:
+          image_ref: '${{ steps.registry_and_owner.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
+          severity: ${{ inputs.trivy_severity }}
+          fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
+          ignore-unfixed: ${{ inputs.ignore-unfixed }}
+          report_location: ${{ inputs.report_location }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -147,16 +147,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-        id: docker_build_push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-        with:
-          context: ${{ inputs.context }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta_img.outputs.tags }}
-          labels: ${{ steps.docker_meta_img.outputs.labels }}
-          target: ${{ inputs.target }}
+      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+      #   id: docker_build_push
+      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+      #   with:
+      #     context: ${{ inputs.context }}
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
+      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
+      #     target: ${{ inputs.target }}
   
   trivy_scan:
     name: Trivy scan for uploaded image

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -119,7 +119,7 @@ jobs:
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ contains(inputs.image_tag_generation, 'ticket_from_branch') }}
             type=match,pattern=\d.\d.\d,enable=${{ contains(inputs.image_tag_generation, 'mmp_git_tag') }}
             type=match,pattern=\d.\d,enable=${{ contains(inputs.image_tag_generation, 'mm_git_tag') }}
-            type=sha,enable=${{ inputs.image_tag_generation == 'commit_hash' }}
+            type=sha,enable=${{ contains(inputs.image_tag_generation, 'commit_hash') }}
             type=pep440,pattern={{version}},enable=${{ contains(inputs.image_tag_generation, 'version_git_tag') }}
           flavor: |
             latest=${{ inputs.add_latest_tag }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -149,16 +149,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-      #   id: docker_build_push
-      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-      #   with:
-      #     context: ${{ inputs.context }}
-      #     platforms: linux/amd64
-      #     push: true
-      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
-      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
-      #     target: ${{ inputs.target }}
+      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+        id: docker_build_push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+        with:
+          context: ${{ inputs.context }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta_img.outputs.tags }}
+          labels: ${{ steps.docker_meta_img.outputs.labels }}
+          target: ${{ inputs.target }}
   
   pre_scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -167,7 +167,7 @@ jobs:
     outputs:
       registry_and_owner: ${{ steps.registry_and_owner.outputs.registry_and_owner }}
     steps:
-      - name: Build registry and owner for image to scan
+      - name: Derive registry and owner for image to scan
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -33,10 +33,13 @@ on:
         type: boolean
         default: false
       image_tag_generation:
-        description: "Generation of the image tag: ticket_from_branch(default), commit_hash or version_git_tag"
+        description: "Generation of the image tag: ticket_from_branch, commit_hash or version_git_tag"
         required: false
         type: string
-        default: "ticket_from_branch"
+      custom_image_tag:
+        description: "Custom image tag. Required when tag generation is disabled."
+        required: false
+        type: string
       context:
         description: "Directory where the image is built, defaults to repository root"
         required: false
@@ -92,13 +95,16 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Check repository owners
+      - name: Check conditional inputs
         run: | 
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} && -z "${{ inputs.dockerhub_repository_owner }}" ]]; then
             echo "Error: when pushing to dockerhub a repository owner is required."
             exit 1
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} && -z "${{ inputs.quay_repository_owner }}" ]]; then
             echo "Error: when pushing to quay.io a repository owner is required."
+            exit 1
+          elif [[ -z "${{ inputs.image_tag_generation }}" && -z "${{ inputs.custom_image_tag }}" ]]; then
+            echo "Error: when image tag generation is disabled a custom image tag is required."
             exit 1
           fi
 

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -160,32 +160,36 @@ jobs:
           labels: ${{ steps.docker_meta_img.outputs.labels }}
           target: ${{ inputs.target }}
   
+  pre_scan:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run_trivy_scan }}
+    needs: build_and_upload_image
+    outputs:
+      registry_and_owner: ${{ steps.registry_and_owner.outputs.registry_and_owner }}
+    steps:
+      - name: Build registry and owner for image to scan
+        id: registry_and_owner
+        run: |
+          if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
+            echo "registry_and_owner=docker.io/$dockerhub_repository_owner"
+          elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
+            echo "registry_and_owner=quay.io/$quay_repository_owner"
+          elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
+            echo "registry_and_owner=ghcr.io/$github.repository_owner"
+          fi
+
   trivy_scan:
     name: Trivy scan for uploaded image
-    runs-on: ubuntu-latest
     # Wait for image upload
-    needs: build_and_upload_image
+    needs: [build_and_upload_image, pre_scan]
     if: ${{ inputs.run_trivy_scan }}
     permissions:
       packages: read
       security-events: write
-    steps:
-      - name: Build image ref
-        id: registry_and_owner
-        run: |
-          if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/$dockerhub_repository_owner/"
-          elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
-          echo "registry_and_owner=quay.io/$quay_repository_owner/"
-          elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
-          echo "registry_and_owner=ghcr.io/$github.repository_owner/"
-          fi
-
-      - name: Trivy scan
-        uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
-        with:
-          image_ref: '${{ steps.registry_and_owner.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
-          severity: ${{ inputs.trivy_severity }}
-          fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
-          ignore-unfixed: ${{ inputs.ignore-unfixed }}
-          report_location: ${{ inputs.report_location }}
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
+    with:
+      image_ref: '${{ needs.pre_build.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
+      severity: ${{ inputs.trivy_severity }}
+      fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
+      ignore-unfixed: ${{ inputs.ignore-unfixed }}
+      report_location: ${{ inputs.report_location }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -1,9 +1,11 @@
 # Builds and uploads a docker image and scans it with trivy (optional)
 # Trivy scan can be disabled
 # Image tag options: 
-# image_tag_generation: "ticket_from_branch" The ticket is extracted from the branch name (eg. OPS-123-testing -> OPS-123)
+# image_tag_generation: "ticket_from_branch" The ticket is extracted from the branch name (e.g. OPS-123-testing -> OPS-123)
 # image_tag_generation: "commit_hash" Short hash of the commit is used as tag
 # image_tag_generation: "version_git_tag" Git tag with version is used as tag
+# image_tag_generation: "mmp_git_tag" The tag is derived from git tag with pattern "\d.\d.\d" as mayor.minor.patch version (e.g. infra-tools-1.3.6 -> 1.3.6)
+# image_tag_generation: "mm_git_tag" The tag is derived from git tag with pattern "\d.\d" as mayor.minor version (e.g. infra-tools-1.3.6 -> 1.3)
 # add_latest_tag: true/false "latest" gets added as additiontal image tag
  
 name: Publish image (and run Trivy)
@@ -33,7 +35,7 @@ on:
         type: boolean
         default: false
       image_tag_generation:
-        description: "Comma separated list of image tag generation strategies: ticket_from_branch, commit_hash, version_git_tag, mmp_semver_git_tag oder mm_semver_git_tag"
+        description: "Comma separated list of image tag generation strategies: ticket_from_branch, commit_hash, version_git_tag, mmp_git_tag or mm_git_tag"
         required: false
         type: string
       context:

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -149,16 +149,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-        id: docker_build_push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-        with:
-          context: ${{ inputs.context }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta_img.outputs.tags }}
-          labels: ${{ steps.docker_meta_img.outputs.labels }}
-          target: ${{ inputs.target }}
+      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+      #   id: docker_build_push
+      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+      #   with:
+      #     context: ${{ inputs.context }}
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
+      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
+      #     target: ${{ inputs.target }}
   
   pre_scan:
     runs-on: ubuntu-latest
@@ -171,9 +171,9 @@ jobs:
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/$dockerhub_repository_owner"
+            echo "registry_and_owner=docker.io/$inputs.dockerhub_repository_owner"
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
-            echo "registry_and_owner=quay.io/$quay_repository_owner"
+            echo "registry_and_owner=quay.io/$inputs.quay_repository_owner"
           elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
             echo "registry_and_owner=ghcr.io/$github.repository_owner"
           fi
@@ -188,7 +188,7 @@ jobs:
       security-events: write
     uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@5
     with:
-      image_ref: '${{ needs.pre_build.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
+      image_ref: '${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}'
       severity: ${{ inputs.trivy_severity }}
       fail_on_vulnerabilites: ${{ inputs.fail_on_vulnerabilites }}
       ignore-unfixed: ${{ inputs.ignore-unfixed }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -115,7 +115,8 @@ jobs:
           tags: |
             type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ contains(inputs.image_tag_generation, 'ticket_from_branch') }}
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ contains(inputs.image_tag_generation, 'ticket_from_branch') }}
-            type=semver,value={{tag}},pattern={{version}},enable=${{ contains(inputs.image_tag_generation, 'mmp_semver_git_tag') }}
+            type=match,pattern=\d.\d.\d,enable=${{ contains(inputs.image_tag_generation, 'mmp_git_tag') }}
+            type=match,pattern=\d.\d,enable=${{ contains(inputs.image_tag_generation, 'mm_git_tag') }}
             type=sha,enable=${{ inputs.image_tag_generation == 'commit_hash' }}
             type=pep440,pattern={{version}},enable=${{ contains(inputs.image_tag_generation, 'version_git_tag') }}
           flavor: |
@@ -144,16 +145,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       
-      - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
-        id: docker_build_push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
-        with:
-          context: ${{ inputs.context }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.docker_meta_img.outputs.tags }}
-          labels: ${{ steps.docker_meta_img.outputs.labels }}
-          target: ${{ inputs.target }}
+      # - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
+      #   id: docker_build_push
+      #   uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
+      #   with:
+      #     context: ${{ inputs.context }}
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: ${{ steps.docker_meta_img.outputs.tags }}
+      #     labels: ${{ steps.docker_meta_img.outputs.labels }}
+      #     target: ${{ inputs.target }}
   
   trivy_scan:
     name: Trivy scan for uploaded image

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -14,16 +14,19 @@ on:
         description: "Name of the image to build"
         required: true
         type: string
-      context:
-        description: "Directory where the image is built, defaults to repository root"
-        required: false
-        default: "./"
-        type: string
       container_registry:
-        description: "Target container registry. Currently only ghcr.io(default) is implemented."
+        description: "Comma separated list of target container registries. Possible registries are ghcr.io (default), quay.io and dockerhub."
         required: false
         type: string
         default: "ghcr.io"
+      dockerhub_repository_owner:
+        description: "The owner of the repository in dockerhub. Required when pushing to dockerhub."
+        required: false
+        type: string
+      quay_repository_owner:
+        description: "The owner of the repository in quay.io. Required when pushing to quay.io."
+        required: false
+        type: string  
       add_latest_tag:
         description: "Whether latest should be added as image tag (default: false)"
         required: false
@@ -34,6 +37,11 @@ on:
         required: false
         type: string
         default: "ticket_from_branch"
+      context:
+        description: "Directory where the image is built, defaults to repository root"
+        required: false
+        default: "./"
+        type: string
       run_trivy_scan:
         description: "Whether a trivy scan should run on the uploaded image (default: true)"
         required: false
@@ -64,10 +72,19 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: false
+      DOCKER_TOKEN:
+        required: false
+      QUAY_USERNAME:
+        required: false
+      QUAY_TOKEN:
+        required: false
 
 jobs:
   build_and_upload_image:
-    name: Publish image to ${{ inputs.container_registry }}
+    name: Publish image
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.docker_build_push.outputs.digest }}
@@ -75,13 +92,27 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Check repository owners
+        run: | 
+          if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} && -z "${{ inputs.dockerhub_repository_owner }}" ]]; then
+            echo "Error: when pushing to dockerhub a repository owner is required."
+            exit 1
+          elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} && -z "${{ inputs.quay_repository_owner }}" ]]; then
+            echo "Error: when pushing to quay.io a repository owner is required."
+            exit 1
+          fi
+
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      
       - name: Build image name and tags
         id: docker_meta_img
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
-          images: ${{ inputs.container_registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
+          images: | 
+            name="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'ghcr.io') }}
+            name="docker.io/${{ inputs.dockerhub_repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'dockerhub') }}
+            name="quay.io/${{ inputs.quay_repository_owner }}/${{ inputs.image_name }}",enable=${{ contains(inputs.container_registry, 'quay.io') }}
           tags: |
             type=match,value={{branch}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
             type=match,value=${{ github.head_ref || ''}},pattern=^\w+?-\d+,enable=${{ inputs.image_tag_generation == 'ticket_from_branch' }}
@@ -89,13 +120,30 @@ jobs:
             type=pep440,pattern={{version}},enable=${{ inputs.image_tag_generation == 'version_git_tag' }}
           flavor: |
             latest=${{ inputs.add_latest_tag }}
-      - name: Login (GHCR)
+      
+      - name: Log into ghcr.io
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d #v3.0.0
-        if: ${{ inputs.container_registry == 'ghcr.io' }}
+        if: ${{ contains(inputs.container_registry, 'ghcr.io') }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Log into dockerhub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d #v3.0.0
+        if: ${{ contains(inputs.container_registry, 'dockerhub') }}
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: Log into quay.io
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d #v3.0.0
+        if: ${{ contains(inputs.container_registry, 'quay.io') }}
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      
       - name: Build and push ${{ inputs.image_name }} to ${{ inputs.container_registry }}
         id: docker_build_push
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1.0
@@ -106,6 +154,7 @@ jobs:
           tags: ${{ steps.docker_meta_img.outputs.tags }}
           labels: ${{ steps.docker_meta_img.outputs.labels }}
           target: ${{ inputs.target }}
+  
   trivy_scan:
     name: Trivy scan for uploaded image
     # Wait for image upload

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -171,11 +171,11 @@ jobs:
         id: registry_and_owner
         run: |
           if [[ ${{ contains(inputs.container_registry, 'dockerhub') }} ]]; then
-            echo "registry_and_owner=docker.io/'$inputs.dockerhub_repository_owner'"
+            echo "registry_and_owner=docker.io/'${{ inputs.dockerhub_repository_owner }}"
           elif [[ ${{ contains(inputs.container_registry, 'quay.io') }} ]]; then
-            echo "registry_and_owner=quay.io/'$inputs.quay_repository_owner'"
+            echo "registry_and_owner=quay.io/${{ inputs.quay_repository_owner }}"
           elif [[ ${{ contains(inputs.container_registry, 'ghcr.io') }} ]]; then
-            echo "registry_and_owner=ghcr.io/'$github.repository_owner'"
+            echo "registry_and_owner=ghcr.io/${{ github.repository_owner }}"
           fi
 
   # trivy_scan:


### PR DESCRIPTION
# Description

- enhanced the workflow so it is now possible to push to multiple registries with one workflow run
- when pushing to quay.io or dockerhub one must use the corresponding owner inputs
- also added new tag generation options for {mayor}.{minor}.{patch} and {mayor}.{minor}

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.