### PR TITLE
Dbp-1672-Fix-push helm chart fails on git diff

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -170,19 +170,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.HELM_CHARTS_REGISTRY_PUBLISHER }}
         run: |
-          set -e
           git config --global user.email "${{ inputs.chart_name }}@dbildungsplattform.de"
           git config --global user.name "${{ inputs.chart_name }}-gha"
           cd helm-charts-registry/automation
           git pull
           git add ${{ inputs.chart_name }}
-          git diff --cached --exit-code
-          status=$?
-          if [[ $status -ne 0 ]]; then
-              #Changes detected in staged files.
-              echo "Changes detected in staged files. Creating a new commit."
-              git commit -m "${{ inputs.chart_name }}"
-              git push origin main 
+          if ! git diff --cached --quiet; then
+            echo "Changes detected in staged files. Creating a new commit."
+            git commit -m "${{ inputs.chart_name }}"
+            git push origin main
           else 
               # No changes detected in staged files.
               echo "No changes detected in staged files. Skipping commit and push."

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -170,18 +170,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.HELM_CHARTS_REGISTRY_PUBLISHER }}
         run: |
+          
           git config --global user.email "${{ inputs.chart_name }}@dbildungsplattform.de"
           git config --global user.name "${{ inputs.chart_name }}-gha"
           cd helm-charts-registry/automation
           git pull
           git add ${{ inputs.chart_name }}
-          git diff --cached --exit-code
-          status=$?
-          if [[ $status -ne 0 ]]; then
+
+
+          # git diff --cached --exit-code
+          #status=$?
+          #if [[ $status -ne 0 ]]; then
               # Changes detected in staged files.
+              #echo "Changes detected in staged files. Creating a new commit."
+              #git commit -m "${{ inputs.chart_name }}"
+              #git push origin main 
+          
+            if ! git diff --cached --quiet; then
               echo "Changes detected in staged files. Creating a new commit."
               git commit -m "${{ inputs.chart_name }}"
-              git push origin main  
+              git push origin main 
           else 
               # No changes detected in staged files.
               echo "No changes detected in staged files. Skipping commit and push."

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -170,23 +170,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.HELM_CHARTS_REGISTRY_PUBLISHER }}
         run: |
-          
+          set -e
           git config --global user.email "${{ inputs.chart_name }}@dbildungsplattform.de"
           git config --global user.name "${{ inputs.chart_name }}-gha"
           cd helm-charts-registry/automation
           git pull
           git add ${{ inputs.chart_name }}
-
-
-          # git diff --cached --exit-code
-          #status=$?
-          #if [[ $status -ne 0 ]]; then
-              # Changes detected in staged files.
-              #echo "Changes detected in staged files. Creating a new commit."
-              #git commit -m "${{ inputs.chart_name }}"
-              #git push origin main 
-          
-            if ! git diff --cached --quiet; then
+          git diff --cached --exit-code
+          status=$?
+          if [[ $status -ne 0 ]]; then
+              #Changes detected in staged files.
               echo "Changes detected in staged files. Creating a new commit."
               git commit -m "${{ inputs.chart_name }}"
               git push origin main 


### PR DESCRIPTION
# Description
Problem:
https://github.com/dBildungsplattform/dbildungs-iam-server/actions/runs/17668054747/job/50215531676?pr=1055
Der Workflow ist beim Befehl:git diff --cached --exit-code abgebrochen
Wir haben set -e aktiv. Das bedeutet: Bash stoppt sofort, wenn ein Befehl ≠ 0 zurückgibt --->Process completed with exit code 1
Lösung:
Wir haben --quiet eingefügt
--quiet → zeigt keine Ausgabe, nur den Status (0 = keine changes, 1 = changes)
In der if condition  wird 0,1 nicht als Fehler behandelt, sondern einfach als condition

Pipeline läuft
https://github.com/dBildungsplattform/dbildungs-iam-server/actions/runs/17671091659

