### PR TITLE
feat(image-publish): DBP-2191 enable build args for image publish

### DIFF
--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -90,6 +90,11 @@ on:
         required: false
         default: ""
         type: string
+      build-args:
+        description: "Multiline build args to be used for the docker build step (FOO=bar newline syntax)"
+        required: false
+        default: ""
+        type: string
     secrets:
       DOCKER_USERNAME:
         required: false
@@ -175,6 +180,7 @@ jobs:
           tags: ${{ steps.docker_meta_img.outputs.tags }}
           labels: ${{ steps.docker_meta_img.outputs.labels }}
           target: ${{ inputs.target }}
+          build-args: ${{ inputs.build-args }}
   
   pre_scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -90,7 +90,7 @@ on:
         required: false
         default: ""
         type: string
-      build-args:
+      build_args:
         description: "Multiline build args to be used for the docker build step (FOO=bar newline syntax)"
         required: false
         default: ""
@@ -180,7 +180,7 @@ jobs:
           tags: ${{ steps.docker_meta_img.outputs.tags }}
           labels: ${{ steps.docker_meta_img.outputs.labels }}
           target: ${{ inputs.target }}
-          build-args: ${{ inputs.build-args }}
+          build-args: ${{ inputs.build_args }}
   
   pre_scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -91,7 +91,7 @@ on:
         default: ""
         type: string
       build_args:
-        description: "Multiline build args to be used for the docker build step (FOO=bar newline syntax)"
+        description: "Multiline build args to be used for the docker build step (FOO=bar newline syntax). Do NOT pass secrets here, as build args may appear in logs and image layers. For secrets, use safer mechanisms such as BuildKit secrets/secret-files or GitHub Actions/repository secrets."
         required: false
         default: ""
         type: string


### PR DESCRIPTION
# Description
Support build-args to be propagated via inputs to the docker build-and-push action.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/DBP-2191
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.