### PR TITLE
feat: OPS-11677 Allow to skip files on trivy scan

### DIFF
--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -42,6 +42,16 @@ on:
         required: false
         default: 'image'
         type: string
+      skip_dirs:
+        description: 'comma separated list of directories where traversal is skipped'
+        required: false
+        default: ''        
+        type: string
+      skip_files:
+        description: 'comma separated list of files to be skipped'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   trivy_scan:
@@ -63,7 +73,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  #v6.0.3
 
       - name: Run Trivy vulnerability scanner on image or filesystem
-        uses: aquasecurity/trivy-action@84384bd6e777ef152729993b8145ea352e9dd3ef #v0.17.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: ${{ inputs.scan_type }}
           image-ref: ${{ steps.image_ref_lower.outputs.output }} # if scan is for image, will be ignored for filesystem scan
@@ -75,6 +85,8 @@ jobs:
           ignore-unfixed: ${{ inputs.ignore-unfixed }}
           limit-severities-for-sarif: ${{ inputs.limit-severities-for-sarif }}
           trivyignores: ${{ inputs.trivyignores }}
+          skip-dirs: ${{ inputs.skip_dirs }}
+          skip-files: ${{ inputs.skip_files }}
         env:
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db

--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -45,7 +45,7 @@ on:
       skip_dirs:
         description: 'comma separated list of directories where traversal is skipped'
         required: false
-        default: ''        
+        default: ''
         type: string
       skip_files:
         description: 'comma separated list of files to be skipped'

--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -99,7 +99,7 @@ jobs:
           
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ always() }}
-        uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 #v4.31.6
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3        # v4.37.6
         with:
             sarif_file: 'trivy-results.sarif'
             category: 'trivy-${{ inputs.scan_type }}-scan'

--- a/.github/workflows/check-trivy.yaml
+++ b/.github/workflows/check-trivy.yaml
@@ -99,7 +99,7 @@ jobs:
           
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 #v3.37.0
+        uses: github/codeql-action/init@fe4161a26a8629af62121b670040955b330f9af2 #v4.31.6
         with:
             sarif_file: 'trivy-results.sarif'
             category: 'trivy-${{ inputs.scan_type }}-scan'

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -103,7 +103,7 @@ on:
       skip_dirs:
         description: 'comma separated list of directories where traversal is skipped'
         required: false
-        default: ''        
+        default: ''
         type: string
       skip_files:
         description: 'comma separated list of files to be skipped'

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -241,7 +241,7 @@ jobs:
     permissions:
       packages: read
       security-events: write
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@OPS-11677_CronToolsAuto
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@OPS-11677_CronToolsAuto # To be changed to @8 --- IGNORE ---
     with:
       image_ref: ${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}
       severity: ${{ inputs.trivy_severity }}

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -100,6 +100,16 @@ on:
         required: false
         default: checkout
         type: string
+      skip_dirs:
+        description: 'comma separated list of directories where traversal is skipped'
+        required: false
+        default: ''        
+        type: string
+      skip_files:
+        description: 'comma separated list of files to be skipped'
+        required: false
+        default: ''
+        type: string
     secrets:
       DOCKER_USERNAME:
         required: false
@@ -231,7 +241,7 @@ jobs:
     permissions:
       packages: read
       security-events: write
-    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@8
+    uses: dBildungsplattform/dbp-github-workflows/.github/workflows/check-trivy.yaml@OPS-11677_CronToolsAuto
     with:
       image_ref: ${{ needs.pre_scan.outputs.registry_and_owner }}/${{ inputs.image_name }}@${{ needs.build_and_upload_image.outputs.digest }}
       severity: ${{ inputs.trivy_severity }}
@@ -239,6 +249,8 @@ jobs:
       ignore-unfixed: ${{ inputs.ignore-unfixed }}
       report_location: ${{ inputs.report_location }}
       limit-severities-for-sarif:  ${{ inputs.limit-severities-for-sarif }}
+      skip_dirs: ${{ inputs.skip_dirs }}
+      skip_files: ${{ inputs.skip_files }}      
   
   clamav_scan:
     name: ClamAV scan of uploaded image

--- a/.github/workflows/image-publish-trivy.yaml
+++ b/.github/workflows/image-publish-trivy.yaml
@@ -250,7 +250,7 @@ jobs:
       report_location: ${{ inputs.report_location }}
       limit-severities-for-sarif:  ${{ inputs.limit-severities-for-sarif }}
       skip_dirs: ${{ inputs.skip_dirs }}
-      skip_files: ${{ inputs.skip_files }}      
+      skip_files: ${{ inputs.skip_files }}
   
   clamav_scan:
     name: ClamAV scan of uploaded image


### PR DESCRIPTION
As trivy scan will still complain on latest kubectl we will enable skipping files in scan to overcome these failing scans for specific stuff.